### PR TITLE
Adjust team info and footer layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,19 +40,12 @@ authors:
   - name: Simon CAQUÉ
     image: simon.jpg
     twitter: simoncaque
+    linkedin: https://www.linkedin.com/in/simoncaque
     desc: Docteur en droit et diplômé en affaires publiques de l’IEP de Paris, Simon s’est spécialisé
           dans la transformation des administrations, notamment à travers le numérique. Passionné par
           ces sujets, il travaille à l’innovation dans les ministères, enseigne à l’université et
           contribue à MatchID sur les aspects juridiques et financiers.
 
-  - name: Martin GROSS
-    desc: Martin est ingénieur et cofondateur de <a href="https://commoprices.com">CommoPrices.com</a>, la plus grosse plateforme de prix de
-          matières premières he world biggest portal of commodity prices.
-          Il a développé l'interface de validation de matchID pendant son challenge EIG.
-    github: tainmar
-    image: martin.jpeg
-    email: martingross89@gmail.com
-    twitter: tainmar
 
 project:
   general:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
       <strong>Les auteurs</strong>
     </div>
     {% for author in site.authors %}
-    <div class="fr-col-xl-3 fr-col-lg-3 fr-col-md-4 fr-col-sm-6 fr-col-12">
+    <div class="fr-col-xl-4 fr-col-lg-4 fr-col-md-4 fr-col-sm-6 fr-col-12">
       <div class="fr-card fr-enlarge-link">
         <div class="fr-card__body">
           <h4 class="fr-card__title">{{ author.name }}</h4>
@@ -15,6 +15,11 @@
             <a href="{{author.github | prepend: site.github_url}}" class="fr-link">
               <span class="iconify" data-icon="ri:github-line"></span>
             </a>
+            {% if author.linkedin %}
+            <a href="{{ author.linkedin }}" class="fr-link">
+              <span class="iconify" data-icon="ri:linkedin-fill"></span>
+            </a>
+            {% endif %}
           </p>
         </div>
         {% if author.image %}


### PR DESCRIPTION
## Summary
- add Simon Caqué's LinkedIn profile
- remove Martin from authors list
- tweak footer authors grid to show 3 cards per row and display LinkedIn icons

## Testing
- `make build` *(fails: docker not found)*